### PR TITLE
Replace all dots in email addresses

### DIFF
--- a/store/index.js
+++ b/store/index.js
@@ -45,7 +45,7 @@ const createStore = () => {
     actions: {
       async SET_CREDENTIAL ({commit}, { user }) {
         if (!user) return
-        await usersRef.child(user.email.replace('@', '_at_').replace('.', '_dot_')).set({
+        await usersRef.child(user.email.replace('@', '_at_').replace(/\./g, '_dot_')).set({
           name: user.displayName,
           email: user.email,
           icon: user.photoURL


### PR DESCRIPTION
When I first tried to sign-in with my Google account, the following error was shown.

> Unhandled Promise Rejection: Error: Reference.child failed: First argument was an invalid path = "{{my email address}}". Paths must be non-empty strings and can't contain ".", "#", "$", "[", or "]"

Since my email address contains more than one dots and code only replaces the first one, some remained on the path and caused an error.

To fix this, I changed the line to replace all the dots with placeholders.